### PR TITLE
fix when last part ends before last info

### DIFF
--- a/lib/Dicer.js
+++ b/lib/Dicer.js
@@ -159,6 +159,12 @@ Dicer.prototype._oninfo = function(isMatch, data, start, end) {
         this.emit('trailer', data.slice(start + i, end));
       this.reset();
       this._finished = true;
+      // no more parts will be added
+      if (self._parts === 0) {
+        self._realFinish = true;
+        self.emit('finish');
+        self._realFinish = false;
+      }
     }
     if (this._dashes)
       return;

--- a/test/test-endfinish.js
+++ b/test/test-endfinish.js
@@ -1,0 +1,43 @@
+var Dicer = require('..');
+var assert = require('assert');
+
+var CRLF     = '\r\n';
+var boundary = 'boundary';
+
+var write1 = [
+  '--' + boundary,
+  'Content-Type:   text/plain',
+  'Content-Length: 0'
+  ].join(CRLF)
+  + CRLF + CRLF
+  + '--' + boundary ;
+
+var write2 = '--' + CRLF;
+
+var firedEnd    = false;
+var firedFinish = false;
+
+var dicer = new Dicer({boundary: boundary});
+dicer.on('part',   partListener);
+dicer.on('finish', finishListener);
+dicer.write(write1);
+
+function partListener(partReadStream) {
+  partReadStream.on('data', function(){});
+  partReadStream.on('end',  partEndListener)
+}
+function partEndListener() {
+  firedEnd = true;
+  setImmediate(afterEnd);
+}
+function afterEnd() {
+  dicer.end(write2);
+  setImmediate(afterWrite);
+}
+function finishListener() {
+  assert(firedEnd, 'Failed to end before finishing');
+  firedFinish = true;
+}
+function afterWrite() {
+  assert(firedFinish, 'Failed to finish');
+}


### PR DESCRIPTION
In rare cases, it seems the end for the last part can fire before the info event for the terminating delimiter fires.

A a result, the finish event on the parser never fires, so the application never knows parsing is done (other than listening for the end event on a readable stream piped to Dicer, but the end event can also fire before the finish event).