### PR TITLE
unpause after backpressure when all parts have finished

### DIFF
--- a/lib/Dicer.js
+++ b/lib/Dicer.js
@@ -174,7 +174,7 @@ Dicer.prototype._oninfo = function(isMatch, data, start, end) {
   if (!this._part) {
     this._part = new PartStream(this._partOpts);
     this._part._read = function(n) {
-        self._unpause();
+      self._unpause();
     };
     ev = this._isPreamble ? 'preamble' : 'part';
     if (this._events[ev])

--- a/lib/Dicer.js
+++ b/lib/Dicer.js
@@ -174,14 +174,7 @@ Dicer.prototype._oninfo = function(isMatch, data, start, end) {
   if (!this._part) {
     this._part = new PartStream(this._partOpts);
     this._part._read = function(n) {
-      if (!self._pause)
-        return;
-      self._pause = false;
-      if (self._cb) {
-        var cb = self._cb;
-        self._cb = undefined;
-        cb();
-      }
+        self._unpause();
     };
     ev = this._isPreamble ? 'preamble' : 'part';
     if (this._events[ev])
@@ -213,10 +206,14 @@ Dicer.prototype._oninfo = function(isMatch, data, start, end) {
     else {
       ++this._parts;
       this._part.on('end', function() {
-        if (--self._parts === 0 && self._finished) {
-          self._realFinish = true;
-          self.emit('finish');
-          self._realFinish = false;
+        if (--self._parts === 0) {
+          if (self._finished) {
+            self._realFinish = true;
+            self.emit('finish');
+            self._realFinish = false;
+          } else {
+            self._unpause();
+          }
         }
       });
     }
@@ -225,6 +222,18 @@ Dicer.prototype._oninfo = function(isMatch, data, start, end) {
     this._ignoreData = false;
     this._justMatched = true;
     this._dashes = 0;
+  }
+};
+
+Dicer.prototype._unpause = function() {
+  if (!this._pause)
+    return;
+
+  this._pause = false;
+  if (this._cb) {
+    var cb = this._cb;
+    this._cb = undefined;
+    cb();
   }
 };
 

--- a/test/test-endfinish.js
+++ b/test/test-endfinish.js
@@ -20,13 +20,13 @@ var firedEnd    = false;
 var firedFinish = false;
 
 var dicer = new Dicer({boundary: boundary});
-dicer.on('part',   partListener);
+dicer.on('part', partListener);
 dicer.on('finish', finishListener);
 dicer.write(writePart+writeSep);
 
 function partListener(partReadStream) {
   partReadStream.on('data', function(){});
-  partReadStream.on('end',  partEndListener)
+  partReadStream.on('end', partEndListener);
 }
 function partEndListener() {
   firedEnd = true;
@@ -54,22 +54,22 @@ var dicer2 = null;
 
 function test2() {
   dicer2 = new Dicer({boundary: boundary});
-  dicer2.on('part',   pausePartListener);
+  dicer2.on('part', pausePartListener);
   dicer2.on('finish', pauseFinish);
   dicer2.write(writePart+writeSep, 'utf8', pausePartCallback);
   setImmediate(pauseAfterWrite);
 }
 function pausePartListener(partReadStream) {
   partReadStream.on('data', function(){});
-  partReadStream.on('end',  function(){})
+  partReadStream.on('end', function(){});
   var realPush = partReadStream.push;
   partReadStream.push = function fakePush() {
-	realPush.apply(partReadStream, arguments);
+    realPush.apply(partReadStream, arguments);
     if (!isPausePush)
       return true;
     isPausePush = false;
     return false;
-  }
+  };
 }
 function pauseAfterWrite() {
   dicer2.end(writeEnd);

--- a/test/test-endfinish.js
+++ b/test/test-endfinish.js
@@ -4,15 +4,17 @@ var assert = require('assert');
 var CRLF     = '\r\n';
 var boundary = 'boundary';
 
-var write1 = [
-  '--' + boundary,
+var writeSep = '--' + boundary;
+
+var writePart = [
+  writeSep,
   'Content-Type:   text/plain',
   'Content-Length: 0'
   ].join(CRLF)
   + CRLF + CRLF
-  + '--' + boundary ;
+  + 'some data' + CRLF;
 
-var write2 = '--' + CRLF;
+var writeEnd = '--' + CRLF;
 
 var firedEnd    = false;
 var firedFinish = false;
@@ -20,7 +22,7 @@ var firedFinish = false;
 var dicer = new Dicer({boundary: boundary});
 dicer.on('part',   partListener);
 dicer.on('finish', finishListener);
-dicer.write(write1);
+dicer.write(writePart+writeSep);
 
 function partListener(partReadStream) {
   partReadStream.on('data', function(){});
@@ -31,13 +33,55 @@ function partEndListener() {
   setImmediate(afterEnd);
 }
 function afterEnd() {
-  dicer.end(write2);
+  dicer.end(writeEnd);
   setImmediate(afterWrite);
 }
 function finishListener() {
   assert(firedEnd, 'Failed to end before finishing');
   firedFinish = true;
+  test2();
 }
 function afterWrite() {
   assert(firedFinish, 'Failed to finish');
+}
+
+var isPausePush = true;
+
+var firedPauseCallback = false;
+var firedPauseFinish = false;
+
+var dicer2 = null;
+
+function test2() {
+  dicer2 = new Dicer({boundary: boundary});
+  dicer2.on('part',   pausePartListener);
+  dicer2.on('finish', pauseFinish);
+  dicer2.write(writePart+writeSep, 'utf8', pausePartCallback);
+  setImmediate(pauseAfterWrite);
+}
+function pausePartListener(partReadStream) {
+  partReadStream.on('data', function(){});
+  partReadStream.on('end',  function(){})
+  var realPush = partReadStream.push;
+  partReadStream.push = function fakePush() {
+	realPush.apply(partReadStream, arguments);
+    if (!isPausePush)
+      return true;
+    isPausePush = false;
+    return false;
+  }
+}
+function pauseAfterWrite() {
+  dicer2.end(writeEnd);
+  setImmediate(pauseAfterEnd);
+}
+function pauseAfterEnd() {
+  assert(firedPauseCallback, 'Failed to call callback after pause');
+  assert(firedPauseFinish, 'Failed to finish after pause');
+}
+function pauseFinish() {
+  firedPauseFinish = true;
+}
+function pausePartCallback() {
+  firedPauseCallback = true;
 }


### PR DESCRIPTION
During stress testing, we found another rare condition where Dicer doesn't finish. When the part writer provides backpressure before any part has finished and the buffered writes either end immediately after a part boundary or after the first hyphen following the last part boundary, Dicer doesn't leave the pause state.

The fix that worked in our stress testing was to unpause by calling the paused callback when input has not finished but there are no parts.

The pull request includes a unit test.

If the pull request is acceptable, could you also cut a new release so we could consume Dicer with the fix.

Thanks for implementing Dicer -- the library is really useful and works well for us.
