### PR TITLE
"terminated error ..." should emit only once

### DIFF
--- a/lib/Dicer.js
+++ b/lib/Dicer.js
@@ -59,7 +59,6 @@ Dicer.prototype.emit = function(ev) {
     if (!this._finished) {
       var self = this;
       process.nextTick(function() {
-        self.emit('error', new Error('Unexpected end of multipart data'));
         if (self._part && !self._ignoreData) {
           var type = (self._isPreamble ? 'Preamble' : 'Part');
           self._part.emit('error', new Error(type + ' terminated early due to unexpected end of multipart data'));
@@ -71,6 +70,7 @@ Dicer.prototype.emit = function(ev) {
           });
           return;
         }
+        self.emit('error', new Error('Unexpected end of multipart data'));
         self._realFinish = true;
         self.emit('finish');
         self._realFinish = false;


### PR DESCRIPTION
"terminated early due to unexpected end of multipart data"
Should be emitted only once since its will be handled once and then the response will be thrown.