### PR TITLE
package.json: Add "files" attribute for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "scripts": {
     "test": "node test/test.js"
   },
+  "files": [
+    "lib"
+  ],
   "engines": { "node": ">=4.5.0" },
   "keywords": [ "parser", "parse", "parsing", "multipart", "form-data", "streaming" ],
   "licenses": [ { "type": "MIT", "url": "http://github.com/mscdex/dicer/raw/master/LICENSE" } ],


### PR DESCRIPTION
Add "files" attributes for npm to only pack necessary files.
This is can reduce package size a lot under `node_modules`.

see https://docs.npmjs.com/misc/developers